### PR TITLE
Fixed JsTrans to use require instead of require_once when including message files

### DIFF
--- a/JsTrans.php
+++ b/JsTrans.php
@@ -51,7 +51,7 @@ class JsTrans
                     if (!isset($dictionary[$lang][$cat])) $dictionary[$lang][$cat] = array();
 
                     $messagefile = $messagesFolder . '/' . $lang . '/' . $cat . '.php';
-                    if (file_exists($messagefile)) $dictionary[$lang][$cat] = require_once($messagefile);
+                    if (file_exists($messagefile)) $dictionary[$lang][$cat] = require($messagefile);
                 }
             }
 


### PR DESCRIPTION
Fixed the messaging to use require instead of require_once - otherwise message files included in yii elsewhere will not be complied into the js dictionary file
