### PR TITLE
Save dictionary file in public asset folder

### DIFF
--- a/JsTrans.php
+++ b/JsTrans.php
@@ -33,13 +33,13 @@ class JsTrans
         $this->_assetsPath = dirname(__FILE__) . '/assets';
         $this->_publishPath = $assetManager->getPublishedPath($this->_assetsPath);
 
+        // create hash
+        $hash = substr(md5(implode($categories) . ':' . implode($languages) ), 0, 10);
+        $dictionaryFile = "JsTrans.dictionary.{$hash}.js";
+
         // publish assets and generate dictionary file if neccessary
         if (!file_exists($this->_publishPath) || YII_DEBUG) {
             $this->_publishPath = $assetManager->getPublishedPath($this->_assetsPath);
-
-            // create hash
-            $hash = substr(md5(implode($categories) . ':' . implode($languages) ), 0, 10);
-            $dictionaryFile = "JsTrans.dictionary.{$hash}.js";
 
             // declare config (passed to JS)
             $config = array('language' => $defaultLanguage);


### PR DESCRIPTION
I use JsTrans and had some problems. When deleting public assets folder, JsTrans did not regenerate files.

JsTrans only checked if dictionary file existed in JsTrans own file structure (which never gets deleted). It's bad practice to store temporary files in source directories in the first place.

Therefore I moved the directory file to public assets folder. Much better! Also, now it checks if the public asset folder exits, and regenerate if not.

Sorry for messy diff, but I also did some minor finishing touches here and there :-)
